### PR TITLE
Test against Django `1.10` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ This app is compatible with the following django versions:
 
  - Django 1.8.x
  - Django 1.9.x
+ - Djang0 1.10.x
 
 ## ChangeLog
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -44,3 +44,16 @@ DATABASES = {
 ROOT_URLCONF = 'app.urls'
 
 LOGIN_URL = 'admin:login'
+
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.template.context_processors.debug',
+            'django.template.context_processors.request',
+            'django.contrib.auth.context_processors.auth',
+            'django.contrib.messages.context_processors.messages',
+        ],
+    },
+}]

--- a/omniforms/tests/test_models.py
+++ b/omniforms/tests/test_models.py
@@ -2007,7 +2007,7 @@ class OmniFormSaveInstanceHandlerTestCase(OmniFormTestCaseStub):
         """
         self.assertTrue(issubclass(OmniFormSaveInstanceHandler, OmniFormHandler))
 
-    @skipUnless(django.get_version() < '1.9', 'Tests functionality specific to django versions < 1.9')
+    @skipUnless(django.VERSION < (1, 9, 0, 'final', 0), 'Tests functionality specific to django versions < 1.9')
     @patch('django.forms.models.save_instance')
     def test_handle_django_lte_18(self, patched_method):
         """
@@ -2024,7 +2024,7 @@ class OmniFormSaveInstanceHandlerTestCase(OmniFormTestCaseStub):
             construct=False
         )
 
-    @skipUnless(django.get_version() >= '1.9', 'Tests functionality specific to django versions >= 1.9')
+    @skipUnless(django.VERSION >= (1, 9, 0, 'final', 0), 'Tests functionality specific to django versions >= 1.9')
     def test_handle(self):
         """
         The handle method should call down to the save_instance function

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
+[coverage:run]
+omit = *migrations*,*tests*,.tox*
+parallel = true
+
+[coverage:report]
+skip_covered = true
+
 [metadata]
 description-file = README.md

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19},flake8,coverage
+envlist = {py27,py34,py35}-django{18,19,110},flake8,coverage
 
 
 [testenv]
@@ -19,6 +19,7 @@ deps =
     mock==2.0.0
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.20
     coverage==4.2.0
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19},flake8
+envlist = {py27,py34,py35}-django{18,19},flake8,coverage
 
 
 [testenv]
-commands = django-admin.py test
+commands =
+    coverage run {envbindir}/django-admin.py test
+
+
 setenv =
     DJANGO_SETTINGS_MODULE=app.settings
     PYTHONPATH={toxinidir}
@@ -16,6 +19,7 @@ deps =
     mock==2.0.0
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    coverage==4.2.0
 
 
 [testenv:py27]
@@ -34,3 +38,11 @@ basepython=python3.5
 commands = flake8 .
 deps =
     flake8
+
+
+[testenv:coverage]
+commands =
+    coverage combine
+    coverage report
+deps =
+    coverage


### PR DESCRIPTION
# Added coverage:
I added coverage to ensure the tests could be trusted to capture all error in the library while against Django `1.10` .

# Added basic `TEMPLATES` settings to `app/settings.py`:
For the tests to pass against django `1.10` they required the `TEMPLATES` settings.

# Fix string comparison bug in `omniforms/tests/test_models.py`:
`django.get_version()` returns the version of django as a string.
This caused issues when I installed django `1.10` as  `'1.10'` is less than `'1.9'`.
By comparing against the version tuple (`django.VERSION`) we avoid this problem.