### PR TITLE
Added dynamically generated template field help text with available context variables to OmniFormEmailHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This app is compatible with the following django versions:
 
  - Django 1.8.x
  - Django 1.9.x
- - Djang0 1.10.x
+ - Django 1.10.x
 
 ## ChangeLog
 

--- a/omniforms/admin_views.py
+++ b/omniforms/admin_views.py
@@ -157,6 +157,17 @@ class OmniModelFormRelatedView(OmniFormAdminView):
             'content_type': forms.HiddenInput,
         }
 
+    def _get_help_texts(self):
+        """
+        Returns a dict of form help texts keyed by field name
+
+        :return: Dict of field help texts
+        """
+        return {
+            field.name: field.help_text
+            for field in self.model._meta.fields
+        }
+
     def get_form_class(self):
         """
         Method for generating a form class for the view
@@ -167,7 +178,8 @@ class OmniModelFormRelatedView(OmniFormAdminView):
             self.model,
             exclude=self.exclude,
             form=self.form_class,
-            widgets=self._get_form_widgets()
+            widgets=self._get_form_widgets(),
+            help_texts=self._get_help_texts(),
         )
 
     def get_success_url(self):

--- a/omniforms/models.py
+++ b/omniforms/models.py
@@ -753,7 +753,7 @@ class OmniFormSaveInstanceHandler(OmniFormHandler):
     def handle(self, form):
         """
         Handle method
-        Sends an email to the specified recipients
+        Saves object instance to the database
 
         :param form: Valid form instance
         :type form: django.forms.Form

--- a/omniforms/models.py
+++ b/omniforms/models.py
@@ -655,6 +655,18 @@ class OmniFormEmailHandler(OmniFormHandler):
     recipients = models.TextField()
     template = models.TextField()
 
+    def __init__(self, *args, **kwargs):
+        super(OmniFormEmailHandler, self).__init__(*args, **kwargs)
+
+        # Dynamically update 'template' field help text with variables
+        # that are available
+        used_fields = self.form.used_field_names
+        self._meta.get_field('template').help_text = (
+            'Variables available: {used_fields}.'.format(
+                used_fields=', '.join(used_fields)
+            )
+        )
+
     class Meta(object):
         """
         Django properties

--- a/omniforms/models.py
+++ b/omniforms/models.py
@@ -660,12 +660,13 @@ class OmniFormEmailHandler(OmniFormHandler):
 
         # Dynamically update 'template' field help text with variables
         # that are available
-        used_fields = self.form.used_field_names
-        self._meta.get_field('template').help_text = (
-            'Variables available: {used_fields}.'.format(
-                used_fields=', '.join(used_fields)
+        if self.form:
+            used_fields = self.form.used_field_names
+            self._meta.get_field('template').help_text = (
+                'Variables available: {used_fields}.'.format(
+                    used_fields=', '.join(used_fields)
+                )
             )
-        )
 
     class Meta(object):
         """

--- a/omniforms/templates/admin/omniforms/omnimodelform/related_form.html
+++ b/omniforms/templates/admin/omniforms/omnimodelform/related_form.html
@@ -69,6 +69,7 @@
                     <div>
                         <label{% if field.field.required %} class="required"{% endif %} for="{{ field.auto_id }}">{{ field.label }}</label>
                         {{ field }}
+                        {% if field.help_text %}<p class="help">{{ field.help_text|safe }}</p>{% endif %}
                     </div>
                 </div>
                 {% endfor %}

--- a/omniforms/tests/test_models.py
+++ b/omniforms/tests/test_models.py
@@ -450,6 +450,15 @@ class OmniModelFormTestCase(TestCase):
         self.assertIn('slug', model_field_names)
         self.assertIn('other_models', model_field_names)
 
+    def test_template_field_dynamic_help_text(self):
+        """
+        The model should dynamically update template field help text to
+        list the variables available in the context
+        """
+        help_text = self.handler_1._meta.get_field('template').help_text
+        self.assertIn(self.field_1.name, help_text)
+        self.assertIn(self.field_2.name, help_text)
+
 
 class OmniFieldTestCase(TestCase):
     """


### PR DESCRIPTION
The PR resolves issues #9 and #11 by extension, as discussed in the issue threads.

One thing that should be noted is that because of implementing it at the model level, the help text is available only while editing `OmniFormEmailHandler` , not on its creation form.