### PR TITLE
Improvement/lazy help text

### DIFF
--- a/omniforms/admin_views.py
+++ b/omniforms/admin_views.py
@@ -484,6 +484,16 @@ class OmniModelFormCreateHandlerView(OmniModelFormHandlerView, CreateView):
             self.model = model_class
         return super(OmniModelFormCreateHandlerView, self).dispatch(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        """
+        Creates a handler instance to add to the form so that help text can be generated correctly
+
+        :return: Dict of keyword args to be used when instanciating the form
+        """
+        form_kwargs = super(OmniModelFormCreateHandlerView, self).get_form_kwargs()
+        form_kwargs['instance'] = self.model(form=self.omni_form)
+        return form_kwargs
+
     def get_context_data(self, **kwargs):
         """
         Adds the handler content type id to the context

--- a/omniforms/models.py
+++ b/omniforms/models.py
@@ -647,6 +647,38 @@ class OmniFormHandler(models.Model):
         return reverse('admin:omniforms_omnimodelform_updatehandler', args=[self.object_id, self.pk])
 
 
+@python_2_unicode_compatible
+class TemplateHelpTextLazy(object):
+    """
+    Lazy object for generating help text for the
+    OmniFormEmailHandler models 'template' field
+    """
+    def __init__(self, instance):
+        """
+        Sets up the instance
+
+        :param instance: OmniFormEmailHandler model instance
+        :type instance: OmniFormEmailHandler
+        """
+        super(TemplateHelpTextLazy, self).__init__()
+        self.instance = instance
+
+    def __str__(self):
+        """
+        Generates the string representation of the help text
+
+        :return: Help text content
+        """
+        help_text = 'Please enter the content of the email here.'
+        if self.instance.form:
+            used_fields = self.instance.form.used_field_names
+            if len(used_fields) > 0:
+                help_text += ' Available tokens are {0}'.format(
+                    ', '.join(['{{ %s }}' % field for field in used_fields])
+                )
+        return help_text
+
+
 class OmniFormEmailHandler(OmniFormHandler):
     """
     Email handler for the form builder
@@ -656,17 +688,17 @@ class OmniFormEmailHandler(OmniFormHandler):
     template = models.TextField()
 
     def __init__(self, *args, **kwargs):
-        super(OmniFormEmailHandler, self).__init__(*args, **kwargs)
+        """
+        Sets the help text for the 'template' field
 
-        # Dynamically update 'template' field help text with variables
-        # that are available
-        if self.form:
-            used_fields = self.form.used_field_names
-            self._meta.get_field('template').help_text = (
-                'Variables available: {used_fields}.'.format(
-                    used_fields=', '.join(used_fields)
-                )
-            )
+        :param args: Default positional args
+        :type args: ()
+
+        :param kwargs: Default keyword args
+        :type kwargs: {}
+        """
+        super(OmniFormEmailHandler, self).__init__(*args, **kwargs)
+        self._meta.get_field('template').help_text = TemplateHelpTextLazy(self)
 
     class Meta(object):
         """

--- a/omniforms/tests/test_admin_views.py
+++ b/omniforms/tests/test_admin_views.py
@@ -607,6 +607,15 @@ class OmniModelFormCreateHandlerViewTestCase(OmniFormAdminTestCaseStub):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
+    def test_form_instanciated_with_new_instance(self):
+        """
+        The create form should be instanciated with a new (unpersisted) model instance
+        """
+        response = self.client.get(self.url)
+        form = response.context['form']
+        self.assertIsNotNone(form.instance)
+        self.assertEqual(form.instance.form, self.omni_form)
+
     def test_raises_404_if_content_type_invalid(self):
         """
         The view should raise an HTTP 404 response if the specified content type is not a subclass of OmniFormHandler


### PR DESCRIPTION
Makes help text for the EmailHandler lazy to prevent unnecessary queries from being run.
Ensures that the handler create form receives a handler instance (not persisted) so that help text can be generated in the create form. 