### PR TITLE
Test against django 1.11 and python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,26 @@ addons:
     sources:
       - deadsnakes
     packages:
+      - python2.7
+      - python3.4
       - python3.5
+      - python3.6
 env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
+  - TOXENV=py27-django111
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py34-django111
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
+  - TOXENV=py35-django111
+  - TOXENV=py36-django18
+  - TOXENV=py36-django19
+  - TOXENV=py36-django110
+  - TOXENV=py36-django111
   - TOXENV=flake8
 

--- a/README.md
+++ b/README.md
@@ -100,11 +100,19 @@ It is important to note that the dictionary values defined within the `OMNI_FORM
 
 ## Compatibility
 
-This app is compatible with the following django versions:
+### Django
 
  - Django 1.8.x
  - Django 1.9.x
  - Django 1.10.x
+ - Django 1.11.x
+
+### Python
+
+ - Python 2.7
+ - Python 3.4
+ - Python 3.5
+ - Python 3.6
 
 ## ChangeLog
 

--- a/README.rst
+++ b/README.rst
@@ -136,11 +136,21 @@ ImproperlyConfigured exception will be raised.
 Compatibility
 -------------
 
-This app is compatible with the following django versions:
+Django
+~~~~~~
 
 -  Django 1.8.x
 -  Django 1.9.x
 -  Django 1.10.x
+-  Django 1.11.x
+
+Python
+~~~~~~
+
+- Python 2.7
+- Python 3.4
+- Python 3.5
+- Python 3.6
 
 ChangeLog
 ---------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-django{18,19,110},flake8,coverage
+envlist = {py27,py34,py35,py36}-django{18,19,110,111},flake8,coverage
 
 
 [testenv]
@@ -19,21 +19,9 @@ deps =
     mock==2.0.0
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.20
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.20
     coverage==4.2.0
-
-
-[testenv:py27]
-basepython=python2.7
-
-
-[testenv:py34]
-basepython=python3.4
-
-
-[testenv:py35]
-basepython=python3.5
-
 
 [testenv:flake8]
 commands = flake8 .


### PR DESCRIPTION
# Changes

 - Test against django 1.11
 - Test against python 3.6
 - Add supported python versions to compatibility section of README.md and README.rst