### PR TITLE
Ensures that OmniForm.get_form_class returns a subclass of OmniFormBaseForm

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ It is important to note that the dictionary values defined within the `OMNI_FORM
 ## ChangeLog
 
  - 0.1 - Initial Build
+ - 0.2 - Adds ability to create arbitrary non model form instances

--- a/README.rst
+++ b/README.rst
@@ -156,3 +156,4 @@ ChangeLog
 ---------
 
 -  0.1 - Initial Build
+-  0.2 - Adds ability to create arbitrary non model form instances

--- a/omniforms/__init__.py
+++ b/omniforms/__init__.py
@@ -5,7 +5,7 @@ The Omniforms app
 from __future__ import unicode_literals
 
 
-VERSION = ['0', '2', '0', 'rc3']
+VERSION = ['0', '2', '0']
 
 
 def get_version():

--- a/omniforms/models.py
+++ b/omniforms/models.py
@@ -3,7 +3,6 @@
 Models for the omniforms app
 """
 from __future__ import unicode_literals
-from django import forms
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -20,7 +19,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.translation import ugettext_lazy as _
-from omniforms.forms import OmniModelFormBaseForm
+from omniforms.forms import OmniFormBaseForm, OmniModelFormBaseForm
 import re
 
 
@@ -1325,6 +1324,18 @@ class OmniForm(OmniFormBase):
     fields = GenericRelation(OmniField)
     handlers = GenericRelation(OmniFormHandler)
 
+    def _get_base_form_class(self):
+        """
+        Helper method for getting the base ModelForm class for use with the model form factory
+
+        :return: ModelForm instance
+        """
+        return type(
+            self._get_form_class_name(),
+            (OmniFormBaseForm,),
+            {'_handlers': [handler.specific for handler in self.handlers.all()]}
+        )
+
     def get_form_class(self):
         """
         Method for generating a form class from the data contained within the model
@@ -1333,7 +1344,7 @@ class OmniForm(OmniFormBase):
         """
         return type(
             self._get_form_class_name(),
-            (forms.Form,),
+            (self._get_base_form_class(),),
             self._get_fields()
         )
 

--- a/omniforms/tests/test_models.py
+++ b/omniforms/tests/test_models.py
@@ -15,7 +15,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from mock import Mock, patch, PropertyMock
-from omniforms.forms import OmniModelFormBaseForm
+from omniforms.forms import OmniFormBaseForm, OmniModelFormBaseForm
 from omniforms.models import (
     OmniFormBase,
     OmniModelFormBase,
@@ -153,7 +153,7 @@ class OmniFormTestCase(OmniModelFormTestCaseStub):
         The _get_form_class method should return a form class
         """
         form_class = self.omniform.get_form_class()
-        self.assertTrue(issubclass(form_class, forms.Form))
+        self.assertTrue(issubclass(form_class, OmniFormBaseForm))
         self.assertEqual(form_class.__name__, 'OmniFormTestModel')
         form = form_class()
 


### PR DESCRIPTION
# Also

 - Changed version number for final release
 - Updated README changelog info

# Fixes

#21 