### PR TITLE
Prepopulates the form instance for newly created related model instances

### DIFF
--- a/omniforms/__init__.py
+++ b/omniforms/__init__.py
@@ -5,7 +5,7 @@ The Omniforms app
 from __future__ import unicode_literals
 
 
-VERSION = ['0', '3', '0']
+VERSION = ['0', '4', '0']
 
 
 def get_version():

--- a/omniforms/wagtail/model_admin_views.py
+++ b/omniforms/wagtail/model_admin_views.py
@@ -384,7 +384,7 @@ class AddRelatedMixin(object):
         :return: Dict of form kwargs
         """
         form_kwargs = super(AddRelatedMixin, self).get_form_kwargs()
-        form_kwargs['instance'] = self.related_object_model_class()
+        form_kwargs['instance'] = self.related_object_model_class(form=self.instance)
         return form_kwargs
 
 

--- a/omniforms/wagtail/tests/test_model_admin_views.py
+++ b/omniforms/wagtail/tests/test_model_admin_views.py
@@ -349,6 +349,7 @@ class AddFieldViewTestCase(ModelAdminTestCaseStub):
         self.assertTemplateUsed(response, 'modeladmin/omniforms/wagtail/related_form.html')
         self.assertIsInstance(response.context['view'], model_admin_views.AddFieldView)
         self.assertIsInstance(response.context['form'], forms.ModelForm)
+        self.assertEqual(response.context['form'].instance.form, self.form)
         self.assertIsInstance(response.context['model_admin'], WagtailOmniFormModelAdmin)
         self.assertEqual(response.context['instance'], self.form)
         self.assertEqual(
@@ -594,6 +595,7 @@ class AddHandlerViewTestCase(ModelAdminTestCaseStub):
         self.assertTemplateUsed(response, 'modeladmin/omniforms/wagtail/related_form.html')
         self.assertIsInstance(response.context['view'], model_admin_views.AddHandlerView)
         self.assertIsInstance(response.context['form'], forms.ModelForm)
+        self.assertEqual(response.context['form'].instance.form, self.form)
         self.assertIsInstance(response.context['model_admin'], WagtailOmniFormModelAdmin)
         self.assertEqual(response.context['instance'], self.form)
         self.assertEqual(


### PR DESCRIPTION
This will allow extra model validation and constructor logic to be implemented for related models (fields and handlers) at the model level, therefore allowing us to keep the forms used for creating related fields and handlers free of handler/field specific workarounds.

For example, it may be desirable to reference a field associated with the form from a handler.  By providing the form reference to the handler, we can limit the related field choices to include only those associated with the current form instance.