### PR TITLE
Ensure edit/delete links for fields and handlers are not rendered if the form is locked

### DIFF
--- a/omniforms/wagtail/model_admin_views.py
+++ b/omniforms/wagtail/model_admin_views.py
@@ -42,7 +42,7 @@ class OmniFormBaseView(ModelFormView, InstanceSpecificView):
         :return: boolean - whether of not the user has permission to edit the instance
         """
         try:
-            run_permission_hooks('update', self.instance, user)
+            run_permission_hooks('update', self.instance)
         except PermissionDenied:
             return False
         else:
@@ -87,7 +87,7 @@ class CloneFormView(OmniFormBaseView):
         :return: boolean - whether of not the user has permission to edit the instance
         """
         try:
-            run_permission_hooks('clone', self.instance, user)
+            run_permission_hooks('clone', self.instance)
         except PermissionDenied:
             return False
         else:
@@ -371,7 +371,7 @@ class AddRelatedMixin(object):
         :return: boolean - whether of not the user has permission to edit the instance
         """
         try:
-            run_permission_hooks('create', self.instance, user)
+            run_permission_hooks('create', self.instance)
         except PermissionDenied:
             return False
         else:
@@ -507,7 +507,7 @@ class ChangeRelatedObjectInstanceMixin(RelatedObjectInstanceMixin):
         :return: boolean - whether of not the user has permission to edit the instance
         """
         try:
-            run_permission_hooks('update', self.instance, user)
+            run_permission_hooks('update', self.instance)
         except PermissionDenied:
             return False
         else:
@@ -591,7 +591,7 @@ class DeleteRelatedObjectView(RelatedObjectInstanceMixin, OmniFormBaseView):
         :return: boolean - whether of not the user has permission to edit the instance
         """
         try:
-            run_permission_hooks('delete', self.instance, user)
+            run_permission_hooks('delete', self.instance)
         except PermissionDenied:
             return False
         else:

--- a/omniforms/wagtail/templates/modeladmin/omniforms/wagtail/includes/related_controls.html
+++ b/omniforms/wagtail/templates/modeladmin/omniforms/wagtail/includes/related_controls.html
@@ -1,4 +1,6 @@
-{% if edit_url or delete_url %}
+{% firstof edit_url delete_url None as has_url %}
+
+{% if has_url and not form_locked %}
     <div class="c-dropdown" data-dropdown="">
         <a class="c-dropdown__button  u-btn-current">
             {{ button_text }}

--- a/omniforms/wagtail/tests/test_wagtail_hooks.py
+++ b/omniforms/wagtail/tests/test_wagtail_hooks.py
@@ -409,7 +409,25 @@ class FieldControlsRenderingTestCase(TestCase):
             {
                 'button_text': 'Some field',
                 'edit_url': None,
-                'delete_url': None
+                'delete_url': None,
+                'form_locked': False
+            }
+        )
+        soup = BeautifulSoup(rendered, "lxml")
+        self.assertIn('<p>Some field</p>', rendered)
+        self.assertEqual(0, len(soup.find_all('a')))
+
+    def test_renders_paragraph_if_form_locked(self):
+        """
+        The template should just render a paragraph
+        """
+        rendered = render_to_string(
+            'modeladmin/omniforms/wagtail/includes/related_controls.html',
+            {
+                'button_text': 'Some field',
+                'edit_url': '/dummy-path/edit/',
+                'delete_url': '/dummy-path/delete/',
+                'form_locked': True
             }
         )
         soup = BeautifulSoup(rendered, "lxml")
@@ -425,7 +443,8 @@ class FieldControlsRenderingTestCase(TestCase):
             {
                 'button_text': 'Some field',
                 'edit_url': '/some/path/',
-                'delete_url': None
+                'delete_url': None,
+                'form_locked': False
             }
         )
         soup = BeautifulSoup(rendered, "lxml")
@@ -445,7 +464,8 @@ class FieldControlsRenderingTestCase(TestCase):
             {
                 'button_text': 'Some field',
                 'edit_url': None,
-                'delete_url': '/some/path/'
+                'delete_url': '/some/path/',
+                'form_locked': False
             }
         )
         soup = BeautifulSoup(rendered, "lxml")

--- a/omniforms/wagtail/utils.py
+++ b/omniforms/wagtail/utils.py
@@ -1,7 +1,7 @@
 from wagtail.wagtailcore import hooks
 
 
-def run_permission_hooks(action, instance, user):
+def run_permission_hooks(action, instance):
     """
     Simple method that runs permission hooks for the given instance
     Loops through all 'omniform_permission_check' hooks and calls each
@@ -9,11 +9,9 @@ def run_permission_hooks(action, instance, user):
 
      - action: The action being performed (create, update, delete, clone)
      - instance: The instance being operated on
-     - user: The currently logged in user
 
     :param action: The action being performed
     :param instance: The model instance being worked on
-    :param user: The currently logged in user
     """
     for hook in hooks.get_hooks('omniform_permission_check'):
-        hook(action, instance, user)
+        hook(action, instance)


### PR DESCRIPTION
# Note

We need to run permission hooks in contexts where the logged in user is not in scope.  Since user related access can be handled using permissions or other wagtail admin hooks I have removed the user argument from the run_permission_hooks function rather than provide an inconsistent integration.

closes #45  