### PR TITLE
Fix omni_forms installed_apps typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Omni forms is a simple form builder with admin integration for django versions >
 
 Once the package has been installed just add `omni_forms` to `INSTALLED_APPS` in your settings file:
 
-`INSTALLED_APPS += ('omni_forms',)`
+`INSTALLED_APPS += ('omniforms',)`
 
 Once you've done this run `python manage.py migrate` to migrate your database.
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
 [testenv:flake8]
 commands = flake8 .
 deps =
-    flake8
+    flake8==3.5.0
 
 
 [testenv:coverage]


### PR DESCRIPTION
When adding `omni_forms` to `INSTALLED_APPS` for the demo it did not work, had to use `omniforms`, updated README to reflect this.